### PR TITLE
Configurable delimiters

### DIFF
--- a/src/jvfurigana.plugin.js
+++ b/src/jvfurigana.plugin.js
@@ -23,21 +23,25 @@
 
                 forceRender: false         // Will force rendering in non supported browsers. This usually results in no visible
                                            // change in the output though results may vary depending on the browser.
+                beginDelimiter: '（',
+                endDelimiter: '）'
             };
 
             var settings = $.extend({}, this.defaultOptions, options),
 
                 patt = XRegExp('([\\p{Han}]+)' +
-                               '（([\\p{Hiragana}]*)）',
+                               '\\' + settings.beginDelimiter + '([\\p{Hiragana}]*)' + '\\' +settings.endDelimiter,
                                'gim');
             
             return this.each(function() {
 
-                if ($.browser.mozilla || $.browser.opera) {
+                if ($.browser) {
+                  if ($.browser.mozilla || $.browser.opera) {
                     // Incompatible browser detected
                     if (!settings.forceRender) {
                         return;
                     }
+                  }
                 }
 
                 var $this = $(this),


### PR DESCRIPTION
Also a check if `$.browser` exists (was throwing error for me in latest chrome)
Note that I haven't updated the `min.js` and docs.